### PR TITLE
Fix check pool enabled regress

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -11,7 +11,6 @@ declare module '@vue/runtime-core' {
     IconKlayBackArrow: typeof import('~icons/klay/back-arrow')['default']
     IconKlayCalculator: typeof import('~icons/klay/calculator')['default']
     IconKlayChevron: typeof import('~icons/klay/chevron')['default']
-    IconKlayClock: typeof import('~icons/klay/clock')['default']
     IconKlayClose: typeof import('~icons/klay/close')['default']
     IconKlayCollapseArrow: typeof import('~icons/klay/collapse-arrow')['default']
     IconKlayDexLogo: typeof import('~icons/klay/dex-logo')['default']

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -11,6 +11,7 @@ declare module '@vue/runtime-core' {
     IconKlayBackArrow: typeof import('~icons/klay/back-arrow')['default']
     IconKlayCalculator: typeof import('~icons/klay/calculator')['default']
     IconKlayChevron: typeof import('~icons/klay/chevron')['default']
+    IconKlayClock: typeof import('~icons/klay/clock')['default']
     IconKlayClose: typeof import('~icons/klay/close')['default']
     IconKlayCollapseArrow: typeof import('~icons/klay/collapse-arrow')['default']
     IconKlayDexLogo: typeof import('~icons/klay/dex-logo')['default']

--- a/src/modules/ModuleFarming/Pool.vue
+++ b/src/modules/ModuleFarming/Pool.vue
@@ -84,7 +84,7 @@ const {
   computed(() => pool.value.pairId),
   FARMING_CONTRACT_ADDRESS,
 )
-whenever(expanded, triggerCheckEnabled)
+whenever(() => expanded.value && !enabled.value, triggerCheckEnabled)
 
 const loading = computed(() => {
   // FIXME include "enableTask" pending here too?

--- a/src/modules/ModuleStaking/Pool.vue
+++ b/src/modules/ModuleStaking/Pool.vue
@@ -81,7 +81,7 @@ const {
   computed(() => pool.value.stakeToken.id),
   computed(() => pool.value.id),
 )
-whenever(expanded, triggerCheckEnabled)
+whenever(() => expanded.value && !enabled.value, triggerCheckEnabled)
 
 function stake() {
   modalOperation.value = ModalOperation.Stake


### PR DESCRIPTION
Prior to refactoring, the allowance check was performed only when the pool was expanded for the first time. Returned this check