### PR TITLE
[fix]: avoid `import.meta.hot?.accept` pattern

### DIFF
--- a/src/modules/ModuleLiquidity/store/add.ts
+++ b/src/modules/ModuleLiquidity/store/add.ts
@@ -287,4 +287,4 @@ export const useLiquidityAddStore = defineStore('liquidity-add', () => {
   }
 })
 
-if (import.meta.hot) import.meta.hot?.accept(acceptHMRUpdate(useLiquidityAddStore, import.meta.hot))
+if (import.meta.hot) import.meta.hot.accept(acceptHMRUpdate(useLiquidityAddStore, import.meta.hot))

--- a/src/modules/ModuleSwap/store/swap.ts
+++ b/src/modules/ModuleSwap/store/swap.ts
@@ -230,4 +230,4 @@ export const useSwapStore = defineStore('swap', () => {
   }
 })
 
-import.meta.hot?.accept(acceptHMRUpdate(useSwapStore, import.meta.hot))
+if (import.meta.hot) import.meta.hot.accept(acceptHMRUpdate(useSwapStore, import.meta.hot))

--- a/src/store/kaikas.ts
+++ b/src/store/kaikas.ts
@@ -50,4 +50,4 @@ export const useKaikasStore = defineStore('kaikas', () => {
   }
 })
 
-import.meta.hot?.accept(acceptHMRUpdate(useKaikasStore, import.meta.hot))
+if (import.meta.hot) import.meta.hot.accept(acceptHMRUpdate(useKaikasStore, import.meta.hot))

--- a/src/store/tokens.ts
+++ b/src/store/tokens.ts
@@ -211,4 +211,4 @@ export const useTokensStore = defineStore('tokens', () => {
   }
 })
 
-import.meta.hot?.accept(acceptHMRUpdate(useTokensStore, import.meta.hot))
+if (import.meta.hot) import.meta.hot.accept(acceptHMRUpdate(useTokensStore, import.meta.hot))


### PR DESCRIPTION
It turned out that this doesn't work in production build:

```ts
import.meta.hot?.accept(...)
```

because it is built to:

```ts
(!1).accept(...)
```

instead of being tree-shaken.