### PR TITLE
[DOPS-1887] Update CI/CD for klaytn-dex-frontend project

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,11 +2,12 @@
 
 def pipeline = new org.js.AppPipeline(
     steps: this,
-    test: false,
-    buildDockerImage: 'build-tools/node:14-alpine',
+    buildDockerImage: 'build-tools/node:16-pnpm7',
     dockerImageName: 'klaytn/klaytn-frontend',
     dockerRegistryCred: 'bot-klaytn-rw',
+    npmRegistries: [:],
     packageManager: 'pnpm',
+    testCmds: ['pnpm format:check','pnpm lint','pnpm typecheck','pnpm test'],
     buildCmds: ['pnpm build'],
     sonarProjectName: 'klaytn-frontend',
     sonarProjectKey: 'jp.co.soramitsu:klaytn-frontend',


### PR DESCRIPTION
# Task

[DOPS-1887] Update CI/CD for klaytn-dex-frontend project

## Changes

1. renew ci

Also builded node image with pnpm 7:  https://github.com/soramitsu/jenkins-library/pull/224

Signed-off-by: Nikita Zaporozhets <zaporozhets@soramitsu.co.jp>

[DOPS-1887]: https://soramitsu.atlassian.net/browse/DOPS-1887