### PR TITLE
[feature]: handle kaikas & metamask locks

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -7,6 +7,7 @@ export {}
 
 declare module '@vue/runtime-core' {
   export interface GlobalComponents {
+    AddressCopy: typeof import('./components/common/AddressCopy.vue')['default']
     CurrencyFormat: typeof import('./components/common/CurrencyFormat.vue')['default']
     CurrencyFormatTruncate: typeof import('./components/common/CurrencyFormatTruncate.vue')['default']
     CurrencyInput: typeof import('./components/common/CurrencyInput.vue')['default']

--- a/src/components/InputTokenPopperInfo.vue
+++ b/src/components/InputTokenPopperInfo.vue
@@ -9,14 +9,6 @@ const props = defineProps<{
 }>()
 
 const balanceAsUsd = computed(() => (props.derivedUsd ? props.derivedUsd.times(props.balance) : null))
-
-const { copy } = useClipboard()
-const copied = autoResetRef(false, 1000)
-
-async function copyAddress() {
-  await copy(props.token.address)
-  copied.value = true
-}
 </script>
 
 <template>
@@ -39,19 +31,10 @@ async function copyAddress() {
         :class="$style.subtitle"
       />
     </div>
-    <div
-      class="flex items-center space-x-1"
+    <AddressCopy
+      :address="token.address"
       :class="$style.addr"
-      @click="copyAddress"
-    >
-      <div class="flex-1 truncate">
-        {{ token.address }}
-      </div>
-      <IconCopyCheck
-        :check="copied"
-        :class="$style.icon"
-      />
-    </div>
+    />
   </div>
 </template>
 
@@ -68,18 +51,5 @@ async function copyAddress() {
   font-weight: 500;
   font-size: 12px;
   line-height: 100%;
-}
-
-.addr {
-  cursor: pointer;
-
-  .icon {
-    color: #adb9ce;
-  }
-
-  &:hover,
-  &:hover .icon {
-    color: vars.$blue;
-  }
 }
 </style>

--- a/src/components/TheHeaderWallet.vue
+++ b/src/components/TheHeaderWallet.vue
@@ -7,7 +7,7 @@ import WalletConnectButton from './WalletConnectButton.vue'
 import WalletIcon from './WalletIcon.vue'
 
 const store = useDexStore()
-const { account, selectedWallet, isChainCorrect, isChainLoaded, isProviderSetupPending } = storeToRefs(store)
+const { account, selectedWallet, isChainCorrect, isChainLoaded, isProviderSetupPending, isEnabled } = storeToRefs(store)
 
 const wrongChain = and(isChainLoaded, not(isChainCorrect))
 
@@ -19,7 +19,7 @@ const addressFormatted = computed(() => account.value && formatAddress(account.v
 
   <SPopover
     v-else
-    placement="bottom"
+    placement="bottom-end"
     distance="8"
     hide-delay="400"
   >
@@ -39,6 +39,11 @@ const addressFormatted = computed(() => account.value && formatAddress(account.v
         />
 
         <span
+          v-else-if="!isEnabled"
+          class="not-enabled"
+        > Not enabled </span>
+
+        <span
           v-if="wrongChain"
           class="wrong-chain"
         > Wrong chain </span>
@@ -55,14 +60,43 @@ const addressFormatted = computed(() => account.value && formatAddress(account.v
     <template #popper="{ show }">
       <div
         v-if="show"
-        class="popper bg-white rounded-lg shadow-md p-4 z-10"
+        class="popper bg-white rounded-lg shadow-md p-4 z-10 space-y-4 flex flex-col"
       >
-        <KlayButton
-          type="primary"
-          @click="store.selectWallet(null)"
+        <h3>
+          {{ selectedWallet === 'kaikas' ? 'Kaikas' : 'MetaMask' }}
+        </h3>
+
+        <div
+          v-if="account"
+          class="connected-account flex items-center space-x-4"
         >
-          Log out
-        </KlayButton>
+          <div>Account:</div>
+          <AddressCopy
+            class="flex-1 overflow-hidden"
+            :address="account"
+          />
+        </div>
+
+        <div class="space-x-4">
+          <KlayButton
+            v-if="!isEnabled"
+            type="primary"
+            size="sm"
+            data-testid="wallet-enable"
+            @click="store.enable()"
+          >
+            Enable
+          </KlayButton>
+
+          <KlayButton
+            type="primary"
+            size="sm"
+            data-testid="wallet-disconnect"
+            @click="store.selectWallet(null)"
+          >
+            Disconnect
+          </KlayButton>
+        </div>
       </div>
     </template>
   </SPopover>
@@ -79,8 +113,8 @@ const addressFormatted = computed(() => account.value && formatAddress(account.v
   }
 }
 
+.not-enabled,
 .wrong-chain {
-  color: vars.$orange;
   font-weight: 600;
   font-size: 14px;
 }
@@ -90,7 +124,13 @@ const addressFormatted = computed(() => account.value && formatAddress(account.v
   font-weight: 700;
 }
 
+.connected-account {
+  font-weight: 500;
+  font-size: 12px;
+}
+
 .popper {
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.15);
+  width: 240px;
 }
 </style>

--- a/src/components/common/AddressCopy.vue
+++ b/src/components/common/AddressCopy.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { Address } from '@/core'
+
+const props = defineProps<{
+  address: Address
+}>()
+
+const { copy } = useClipboard()
+const copied = autoResetRef(false, 1000)
+
+async function copyAddress() {
+  await copy(props.address)
+  copied.value = true
+}
+</script>
+
+<template>
+  <div
+    class="addr flex items-center space-x-1"
+    @click="copyAddress"
+  >
+    <div class="flex-1 truncate">
+      {{ address }}
+    </div>
+    <IconCopyCheck
+      :check="copied"
+      class="icon"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@use '@/styles/vars';
+
+.addr {
+  cursor: pointer;
+
+  .icon {
+    color: #adb9ce;
+  }
+
+  &:hover,
+  &:hover .icon {
+    color: vars.$blue;
+  }
+}
+</style>

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -33,6 +33,15 @@ export interface Kaikas {
     (event: 'networkChanged', cb: () => void): void
   }
   removeListener: (event: string, cb: (...args: any[]) => void) => void
+
+  /**
+   * https://docs.kaikas.io/02_api_reference/01_klaytn_provider#klaytn._kaikas
+   */
+  _kaikas: {
+    isEnabled: () => boolean
+    isApproved: () => Promise<boolean>
+    isUnlocked: () => Promise<boolean>
+  }
 }
 
 export interface Network {

--- a/src/store/dex.ts
+++ b/src/store/dex.ts
@@ -50,6 +50,8 @@ export const useDexStore = defineStore('dex', () => {
     isChainLoaded,
     isProviderSetupPending,
     initialDelayActive,
+    isEnabled,
+    enable,
   } = useWeb3Provider({ network: NETWORK })
 
   const dexByProvider = computed(() => {
@@ -123,6 +125,9 @@ export const useDexStore = defineStore('dex', () => {
 
     openModal,
     initialDelayActive,
+
+    isEnabled,
+    enable,
   }
 })
 


### PR DESCRIPTION
The header wallet menu is enhanced:

- it has "enabled" button now
- "log out" is renamed to "disconnect"

Known issue: when kaikas is locked and "enabled" is clicked, then, after typing a password Kaikas is already enabled, but approves usage of site again without a real need. This leads to "pending" state of `TheHeaderWallet` component while showing the connected address.