### PR TITLE
[fix][KLD-234]: absence of UI for safari browser

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -68,7 +68,10 @@ export function makeTabsArray(data: string[]): Tab[] {
 }
 
 export function formatNumberWithCommas(value: string | number | BigNumber): string {
-  return value.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ',')
+  const a = value.toString().split('.')
+  const beforePeriod = a[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+  const periodAndDecimals = a[1] ? '.' + a[1] : ''
+  return beforePeriod + periodAndDecimals
 }
 
 export function numberToPercent(num: number, precision: number): Percent {


### PR DESCRIPTION
It pertains to the lack of support for lookbehind regexp assertion in Safari: https://caniuse.com/js-regexp-lookbehind.